### PR TITLE
Make compatible with latest scs

### DIFF
--- a/compile_direct.m
+++ b/compile_direct.m
@@ -11,8 +11,8 @@ amd_files = {'amd_order', 'amd_dump', 'amd_postorder', 'amd_post_tree', ...
     'amd_info', 'amd_valid', 'amd_global', 'amd_preprocess', ...
     'SuiteSparse_config'} ;
 for i = 1 : length (amd_files)
-    cmd = sprintf ('%s scs/linsys/direct/external/amd/%s.c', cmd, amd_files {i}) ;
+    cmd = sprintf ('%s scs/linsys/external/amd/%s.c', cmd, amd_files {i}) ;
 end
 
-cmd = sprintf ('%s scs/linsys/direct/external/qdldl/qdldl.c %s scs/linsys/direct/private.c %s %s %s -output scs_direct', cmd, common_scs, flags.link, flags.LOCS, flags.BLASLIB);
+cmd = sprintf ('%s scs/linsys/external/qdldl/qdldl.c %s scs/linsys/cpu/direct/private.c %s %s %s -output scs_direct', cmd, common_scs, flags.link, flags.LOCS, flags.BLASLIB);
 eval(cmd);

--- a/compile_gpu.m
+++ b/compile_gpu.m
@@ -11,8 +11,8 @@ end
 
 % compile gpu
 if (flags.COMPILE_WITH_OPENMP)
-    cmd = sprintf('mex -O %s %s %s COMPFLAGS="/openmp \\$COMPFLAGS" CFLAGS="\\$CFLAGS -fopenmp" scs/linsys/gpu/private.c %s -Iscs -Iscs/include %s %s %s -output scs_gpu',  flags.arr, flags.LCFLAG, common_scs, flags.INCS, flags.link, flags.LOCS, flags.BLASLIB);
+    cmd = sprintf('mex -O %s %s %s COMPFLAGS="/openmp \\$COMPFLAGS" CFLAGS="\\$CFLAGS -fopenmp" scs/linsys/gpu/indirect/private.c %s -Iscs -Iscs/include %s %s %s -output scs_gpu',  flags.arr, flags.LCFLAG, common_scs, flags.INCS, flags.link, flags.LOCS, flags.BLASLIB);
 else
-    cmd = sprintf('mex -O %s %s %s scs/linsys/gpu/private.c %s -Iscs -Iscs/include -Iscs/linsys %s %s %s -output scs_gpu',  flags.arr, flags.LCFLAG, common_scs, flags.INCS, flags.link, flags.LOCS, flags.BLASLIB);
+    cmd = sprintf('mex -O %s %s %s scs/linsys/gpu/indirect/private.c %s -Iscs -Iscs/include -Iscs/linsys %s %s %s -output scs_gpu',  flags.arr, flags.LCFLAG, common_scs, flags.INCS, flags.link, flags.LOCS, flags.BLASLIB);
 end
 eval(cmd);

--- a/compile_indirect.m
+++ b/compile_indirect.m
@@ -2,8 +2,8 @@ function compile_indirect(flags, common_scs)
 
 % compile indirect
 if (flags.COMPILE_WITH_OPENMP)
-    cmd = sprintf('mex -O %s %s %s %s COMPFLAGS="/openmp \\$COMPFLAGS" CFLAGS="\\$CFLAGS -fopenmp" scs/linsys/indirect/private.c %s -Iscs -Iscs/include %s %s %s -output scs_indirect',  flags.arr, flags.LCFLAG, common_scs, flags.INCS, flags.link, flags.LOCS, flags.BLASLIB, flags.INT);
+    cmd = sprintf('mex -O %s %s %s %s COMPFLAGS="/openmp \\$COMPFLAGS" CFLAGS="\\$CFLAGS -fopenmp" scs/linsys/cpu/indirect/private.c %s -Iscs -Iscs/include %s %s %s -output scs_indirect',  flags.arr, flags.LCFLAG, common_scs, flags.INCS, flags.link, flags.LOCS, flags.BLASLIB, flags.INT);
 else
-    cmd = sprintf('mex -O %s %s %s %s scs/linsys/indirect/private.c %s -Iscs -Iscs/include -Iscs/linsys %s %s %s -output scs_indirect',  flags.arr, flags.LCFLAG, common_scs, flags.INCS, flags.link, flags.LOCS, flags.BLASLIB, flags.INT);
+    cmd = sprintf('mex -O %s %s %s %s scs/linsys/cpu/indirect/private.c %s -Iscs -Iscs/include -Iscs/linsys %s %s %s -output scs_indirect',  flags.arr, flags.LCFLAG, common_scs, flags.INCS, flags.link, flags.LOCS, flags.BLASLIB, flags.INT);
 end
 eval(cmd);

--- a/make_scs.m
+++ b/make_scs.m
@@ -11,7 +11,7 @@ flags.LCFLAG = '-DMATLAB_MEX_FILE -DUSE_LAPACK -DCTRLC=1 -DCOPYAMATRIX';
 flags.INCS = '';
 flags.LOCS = '';
 
-common_scs = 'scs/src/linalg.c scs/src/cones.c scs/src/aa.c scs/src/util.c scs/src/scs.c scs/src/ctrlc.c scs/src/normalize.c scs/src/scs_version.c scs/src/rw.c scs_mex.c';
+common_scs = 'scs/src/linalg.c scs/src/cones.c scs/src/aa.c scs/src/util.c scs/src/scs.c scs/src/ctrlc.c scs/src/normalize.c scs/src/scs_version.c scs/linsys/amatrix.c scs/src/rw.c scs_mex.c';
 if (~isempty (strfind (computer, '64')))
     flags.arr = '-largeArrayDims';
 else

--- a/make_scs.m
+++ b/make_scs.m
@@ -11,7 +11,7 @@ flags.LCFLAG = '-DMATLAB_MEX_FILE -DUSE_LAPACK -DCTRLC=1 -DCOPYAMATRIX';
 flags.INCS = '';
 flags.LOCS = '';
 
-common_scs = 'scs/src/linalg.c scs/src/cones.c scs/src/aa.c scs/src/util.c scs/src/scs.c scs/src/ctrlc.c scs/src/normalize.c scs/src/scs_version.c scs/linsys/common.c scs/src/rw.c scs_mex.c';
+common_scs = 'scs/src/linalg.c scs/src/cones.c scs/src/aa.c scs/src/util.c scs/src/scs.c scs/src/ctrlc.c scs/src/normalize.c scs/src/scs_version.c scs/src/rw.c scs_mex.c';
 if (~isempty (strfind (computer, '64')))
     flags.arr = '-largeArrayDims';
 else


### PR DESCRIPTION
I updated the scs submodule to the latest release (v2.1.2) and updated the compilation files to take into account the refactored scs code so that make_scs runs correctly.