### PR TITLE
ci(windows): install MinGW-w64 instead of relying on Visual Studio

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,18 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          # Install a C compiler MATLAB knows about on Windows. The
+          # ``windows-latest`` runner image is being migrated from VS 2022
+          # to VS 2026 (the latter is not on MATLAB R2022b's supported
+          # compilers list), so the previous "rely on whatever Visual
+          # Studio happens to be on the image" approach broke once the
+          # redirect started landing on May 11 2026. Install MinGW-w64
+          # via the MATLAB Package Manager instead — runner-image-
+          # independent and on MATLAB's supported list. macOS/Linux MEX
+          # uses the system clang/gcc and needs no extras.
+          - os: windows-latest
+            extra_products: "MATLAB_Support_for_MinGW-w64_C/C++_Compiler"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -24,6 +36,7 @@ jobs:
         uses: matlab-actions/setup-matlab@v3
         with:
           release: R2022b
+          products: ${{ matrix.extra_products || '' }}
 
       - name: Compile MEX
         uses: matlab-actions/run-command@v3


### PR DESCRIPTION
## Diagnosis

The Mon 2026-05-11 weekly cron run failed on the Windows job: https://github.com/bodono/scs-matlab/actions/runs/25662762362/job/75330776881. macOS and Linux passed.

The MEX compile step error:
```
Supported compiler not detected. You can install the freely available
MinGW-w64 C/C++ compiler...
```
MATLAB R2022b scans Intel / MSVC 2015–2022 / MinGW64 / oneAPI, finds none, exits.

Cause is on the GitHub runner image side, not the code:

- Every weekly cron Apr 13 → May 4 passed (~20 min). May 11 fast-failed (~3 min). No commits in between.
- Per the run annotation: ``NOTICE: windows-2025 requests are being redirected to windows-2025-vs2026 by May 12, 2026``.
- The new image ships VS 2026 / MSVC 19.41+ only. MATLAB R2022b's supported-compilers list ends at VS 2022, so it ignores it.

## Fix

Stop relying on whatever Visual Studio happens to be preinstalled on the runner image. Install **MinGW-w64** via the MATLAB Package Manager (`matlab-actions/setup-matlab`'s `products` input). MinGW-w64 is on R2022b's official supported-compilers list, and the install is runner-image-independent — the next image flip can't break us the same way.

```yaml
- os: windows-latest
  extra_products: "MATLAB_Support_for_MinGW-w64_C/C++_Compiler"
...
- uses: matlab-actions/setup-matlab@v3
  with:
    release: R2022b
    products: ${{ matrix.extra_products || '' }}
```

macOS/Linux jobs are unchanged — MATLAB uses the system clang/gcc there and needs no extras. The `|| ''` coalesces to empty `products:` for those matrix entries.

## Why MinGW is safe here

I went through the usual MinGW-vs-MSVC concerns for this project specifically:

- **`long double`**: not used anywhere in `scs/ src/ matlab/` (grepped). MinGW's 80-bit vs MSVC's 64-bit `long double` would otherwise be a small numerics gotcha.
- **OpenMP**: opt-in via `use_open_mp = false` in `make_scs.m`, with a warning that enabling it can crash MATLAB. The CI build path doesn't enable it, so the `libgomp` (MinGW) vs `vcomp` (MSVC) runtime difference doesn't materialize.
- **CRT mismatch across the MEX boundary**: the usual reason people prefer MSVC for MEX. Doesn't apply — `scs_mex.c`'s surface is pure numeric (`mxArray` in / `mxArray` out). No `FILE*` handles, no memory crossing the boundary, so the CRT-coupling concern is moot. MathWorks officially supports MinGW for exactly this case.
- **Third-party DLL ABI**: not relevant — `make_scs.m` compiles SCS from C source via the MEX command, no pre-built MSVC-linked DLLs.

## End-user impact

None. The `.mltbx` ships prebuilt MEX binaries; end users never see the compiler used to build them.

## Trade-offs accepted

- Setup-MATLAB step gets ~60–120 s slower on cold Windows runs because the MinGW support package has to be downloaded.
- Windows `.mex` files will be a few MB larger due to static-linked libgcc.

Both are worth it to decouple the build from runner-image churn.

## Test plan
- [ ] CI passes on this PR (all three OSes: Windows, macOS, Linux).
- [ ] Smoke test in the `test-toolbox` job (which runs the packaged MEX on each OS) passes on Windows with the MinGW-built binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)